### PR TITLE
Add manifest schema docs, examples, and validator

### DIFF
--- a/docs/MANIFESTS.md
+++ b/docs/MANIFESTS.md
@@ -1,0 +1,22 @@
+# Manifests
+
+Manifests enumerate texts to be processed by the corpus kit. Each manifest is a CSV file with the following **required columns**, all in lowercase:
+
+| column        | description                                                     |
+|---------------|-----------------------------------------------------------------|
+| `path`        | Relative path to the text file on disk.                         |
+| `title`       | Title of the work.                                              |
+| `author`      | Author of the work.                                             |
+| `translator`  | Translator of the work (use `N/A` if not applicable).           |
+| `year`        | Year the work was originally published.                         |
+| `language`    | Language of the text using ISO 639-1 codes (e.g. `en`, `fr`).   |
+| `license_raw` | License description exactly as provided by the source.          |
+| `license_norm`| Normalized license tag (e.g. `pd`, `cc-by-4.0`).                |
+| `source_url`  | URL where the text was obtained.                                |
+
+Use the helper script `scripts/validate_manifest.py` to ensure manifests contain all
+required fields before ingestion:
+
+```bash
+python scripts/validate_manifest.py manifests/your_manifest.csv
+```

--- a/manifests/gutenberg_philosophy_example.csv
+++ b/manifests/gutenberg_philosophy_example.csv
@@ -1,0 +1,2 @@
+path,title,author,translator,year,language,license_raw,license_norm,source_url
+texts/gutenberg/critique_of_pure_reason.txt,Critique of Pure Reason,Immanuel Kant,J. M. D. Meiklejohn,1787,en,Public domain,pd,https://www.gutenberg.org/ebooks/4280

--- a/manifests/wikisource_curated.csv
+++ b/manifests/wikisource_curated.csv
@@ -1,1 +1,2 @@
-title,author,year,language,source_url,output_basename
+path,title,author,translator,year,language,license_raw,license_norm,source_url
+texts/wikisource/the_republic.txt,The Republic,Plato,Benjamin Jowett,1888,en,Public domain,pd,https://en.wikisource.org/wiki/The_Republic

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -23,12 +23,17 @@ def validate_manifest(path: str) -> None:
         reader = csv.DictReader(f)
         if reader.fieldnames is None:
             raise ValueError("missing header")
-        missing_cols = [c for c in REQUIRED_COLUMNS if c not in reader.fieldnames]
-        extra_cols = [c for c in reader.fieldnames if c not in REQUIRED_COLUMNS]
-        if missing_cols:
-            raise ValueError(f"missing columns: {', '.join(missing_cols)}")
-        if extra_cols:
-            raise ValueError(f"unexpected columns: {', '.join(extra_cols)}")
+        header_columns = set(reader.fieldnames)
+        missing_cols = REQUIRED_COLUMNS - header_columns
+        extra_cols = header_columns - REQUIRED_COLUMNS
+
+        if missing_cols or extra_cols:
+            error_messages = []
+            if missing_cols:
+                error_messages.append(f"missing columns: {', '.join(sorted(missing_cols))}")
+            if extra_cols:
+                error_messages.append(f"unexpected columns: {', '.join(sorted(extra_cols))}")
+            raise ValueError("; ".join(error_messages))
         for line_num, row in enumerate(reader, start=2):
             missing = [c for c in REQUIRED_COLUMNS if not row.get(c)]
             if missing:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate manifest CSV files for required columns and non-empty fields."""
+
+import argparse
+import csv
+import sys
+from typing import List
+
+REQUIRED_COLUMNS: List[str] = [
+    "path",
+    "title",
+    "author",
+    "translator",
+    "year",
+    "language",
+    "license_raw",
+    "license_norm",
+    "source_url",
+]
+
+def validate_manifest(path: str) -> None:
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            raise ValueError("missing header")
+        missing_cols = [c for c in REQUIRED_COLUMNS if c not in reader.fieldnames]
+        extra_cols = [c for c in reader.fieldnames if c not in REQUIRED_COLUMNS]
+        if missing_cols:
+            raise ValueError(f"missing columns: {', '.join(missing_cols)}")
+        if extra_cols:
+            raise ValueError(f"unexpected columns: {', '.join(extra_cols)}")
+        for line_num, row in enumerate(reader, start=2):
+            missing = [c for c in REQUIRED_COLUMNS if not row.get(c)]
+            if missing:
+                raise ValueError(f"line {line_num} missing values for: {', '.join(missing)}")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate manifest CSV files.")
+    parser.add_argument("manifests", nargs="+", help="Path(s) to manifest CSV files.")
+    args = parser.parse_args()
+
+    ok = True
+    for path in args.manifests:
+        try:
+            validate_manifest(path)
+            print(f"{path}: OK")
+        except Exception as exc:  # pylint: disable=broad-except
+            print(f"{path}: {exc}", file=sys.stderr)
+            ok = False
+    if not ok:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -4,9 +4,9 @@
 import argparse
 import csv
 import sys
-from typing import List
+from typing import FrozenSet
 
-REQUIRED_COLUMNS: List[str] = [
+REQUIRED_COLUMNS: FrozenSet[str] = frozenset([
     "path",
     "title",
     "author",
@@ -16,7 +16,7 @@ REQUIRED_COLUMNS: List[str] = [
     "license_raw",
     "license_norm",
     "source_url",
-]
+])
 
 def validate_manifest(path: str) -> None:
     with open(path, newline='', encoding='utf-8') as f:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -44,15 +44,15 @@ def main() -> None:
     parser.add_argument("manifests", nargs="+", help="Path(s) to manifest CSV files.")
     args = parser.parse_args()
 
-    ok = True
+    has_errors = False
     for path in args.manifests:
         try:
             validate_manifest(path)
             print(f"{path}: OK")
-        except Exception as exc:  # pylint: disable=broad-except
+        except (ValueError, OSError) as exc:
             print(f"{path}: {exc}", file=sys.stderr)
-            ok = False
-    if not ok:
+            has_errors = True
+    if has_errors:
         sys.exit(1)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document required manifest columns
- add sample manifests for Gutenberg and Wikisource
- provide a script to validate manifests before ingestion

## Testing
- `python scripts/validate_manifest.py manifests/gutenberg_philosophy_example.csv manifests/wikisource_curated.csv`


------
https://chatgpt.com/codex/tasks/task_e_68acd10ac01483238719354690c8fc1c